### PR TITLE
Last.fm: Update scripts location

### DIFF
--- a/last.fm/mpv-lastfm.lua
+++ b/last.fm/mpv-lastfm.lua
@@ -1,7 +1,7 @@
 -- last.fm scrobbler for mpv
 --
 -- Usage:
--- put this file to ~/.mpv/lua
+-- put this file in ~/.config/mpv/scripts
 -- put lastfm.pl somewhere in your PATH
 -- create a file ~/.config/lastfm with the following content:
 -- $login = 'vpupkin';


### PR DESCRIPTION
~/.mpv/lua is deprecated. Using new location instead.