### PR TITLE
mpv-lastfm: Stop scrobbler from printing to stdout

### DIFF
--- a/last.fm/mpv-lastfm.lua
+++ b/last.fm/mpv-lastfm.lua
@@ -40,7 +40,7 @@ function scrobble()
 	if length then
 		optargs = string.format("%s '--duration=%d'", optargs, length)
 	end
-	args = string.format("scrobbler scrobble '%s' '%s' '%s' now", esc(options.username), esc(artist), esc(title))
+	args = string.format("scrobbler scrobble '%s' '%s' '%s' now > /dev/null", esc(options.username), esc(artist), esc(title))
 	msg.debug(args)
 	os.execute(args)
 end


### PR DESCRIPTION
The scrobbler cli tool automatically inherits the stdout of mpv, causing messages printed to stdout to become mixed up in mpv's output.

For example:

```
A: 00:00:50 / 00:01:40 (49%) Cache: 10s+982KB
[lastfm] Scrobbling Joel Nielsen - Surface Tension 3
Track scrobbled.:01:40 (51%) Cache: 10s+950KB
```